### PR TITLE
Enable requests to poll results from all remote origins

### DIFF
--- a/src/app/api/polls/[slug]/results/route.ts
+++ b/src/app/api/polls/[slug]/results/route.ts
@@ -13,5 +13,11 @@ export async function GET(
     "consensus") as keyof StatementReview;
 
   const results = await getPollResults(slug, sort, visitorId);
-  return Response.json(results);
+  return Response.json(results, {
+    headers: {
+      'Access-Control-Allow-Origin': '*',
+      'Access-Control-Allow-Methods': 'GET',
+      'Access-Control-Allow-Headers': 'Content-Type, Authorization',
+    }
+  });
 }


### PR DESCRIPTION
Unable to test because I don't have a Clerk `publishableKey`