### PR TITLE
Allow Private Results Pages

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,3 +54,41 @@ Runs the tests in debug mode.
 
 bun playwright codegen
 Auto generate tests with Codegen.
+
+## Database
+
+### Overview
+
+This project uses [Kysely](https://kysely.dev/) for type-safe database access and migrations, with PostgreSQL as the database engine. Database types are generated using `kysely-codegen` to keep TypeScript types in sync with the actual schema.
+
+### Initial Schema
+
+- The initial schema is set up using the SQL file at `src/db/RUN_BEFORE_MIGRATIONS.sql`. This should be run once to bootstrap a new database before applying TypeScript migrations.
+
+### Migrations
+
+- Migrations are written in TypeScript and stored in `src/db/migrations/`.
+- Use the migration runner script at `src/db/migrate.ts` to manage migrations.
+- Common commands:
+  - `bun run migrate up` — Apply all pending migrations
+  - `bun run migrate down` — Roll back the last migration
+  - `bun run migrate version` — Show migration status
+  - `bun run migrate make <name>` — Create a new migration file from a template
+- Each migration file exports `up` and `down` functions using Kysely's schema builder or raw SQL.
+
+### Making Schema Changes
+
+1. **Create a Migration:**
+   - Run `bun run migrate make <migration_name>` to generate a new migration file in `src/db/migrations/`.
+   - Edit the file to add your schema changes in the `up` function and the reverse in the `down` function.
+2. **Apply the Migration:**
+   - Run `bun run migrate up` to apply your migration to the database.
+3. **Regenerate Types:**
+   - After applying migrations, regenerate the Kysely types (usually with a script or CLI command, e.g., `bun run kysely-codegen`).
+   - This updates the `DB` type used throughout the codebase for type safety.
+
+### Notes
+
+- Always review and test migrations before running them in production.
+- If you add new tables or columns, ensure you update any relevant application logic and types.
+- For questions, see the files in `src/db/` for examples and reference.

--- a/TODO.md
+++ b/TODO.md
@@ -7,7 +7,7 @@
   - [x] There's no link to the results page (unless you are poll creator_)
   - [x] You can't access the results page even by url (says results are private, 404 doesn't make sense to do)
   - [x] Also need to remove the "Copy link to results page" from share dropdown if results private
-  - [ ] Remove download CSV unless it's the poll creator
+  - [x] Remove download CSV unless it's the poll creator
   - [ ] At the end of the poll it just "Thanks for filling this out!"
   - [ ] Check with "Create with AI" should be able to mark results as private
   - [ ] Show on the polls list if the results are private

--- a/TODO.md
+++ b/TODO.md
@@ -5,7 +5,9 @@
   - [x] Add a toggle for this on the poll creation page
   - [x] Make sure the user can edit it after the fact on the poll edit page
   - [x] There's no link to the results page (unless you are poll creator_)
-  - [ ] You can't access the results page even by url (shows 404)
+  - [ ] You can't access the results page even by url (says results are private, 404 doesn't make sense to do)
+  - [ ] Also need to remove the "Copy link to results page" from share dropdown if results private
+  - [ ] Remove download CSV unless it's the poll creator
   - [ ] At the end of the poll it just "Thanks for filling this out!"
   - [ ] Check with "Create with AI" should be able to mark results as private
   - [ ] Show on the polls list if the results are private

--- a/TODO.md
+++ b/TODO.md
@@ -5,8 +5,8 @@
   - [x] Add a toggle for this on the poll creation page
   - [x] Make sure the user can edit it after the fact on the poll edit page
   - [x] There's no link to the results page (unless you are poll creator_)
-  - [ ] You can't access the results page even by url (says results are private, 404 doesn't make sense to do)
-  - [ ] Also need to remove the "Copy link to results page" from share dropdown if results private
+  - [x] You can't access the results page even by url (says results are private, 404 doesn't make sense to do)
+  - [x] Also need to remove the "Copy link to results page" from share dropdown if results private
   - [ ] Remove download CSV unless it's the poll creator
   - [ ] At the end of the poll it just "Thanks for filling this out!"
   - [ ] Check with "Create with AI" should be able to mark results as private

--- a/TODO.md
+++ b/TODO.md
@@ -11,7 +11,7 @@
   - [x] At the end of the poll it just "Thanks for filling this out!"
   - [x] Check with "Create with AI" should be able to mark results as private
   - [x] Show on the polls list if the results are private
-  - [ ] API endpoints
+  - [x] API endpoints
   - [ ] Run on staging DB before pushing pull request
   - [ ] Then Prod
 

--- a/TODO.md
+++ b/TODO.md
@@ -4,7 +4,7 @@
   - [x] Add a column for this in the database
   - [x] Add a toggle for this on the poll creation page
   - [x] Make sure the user can edit it after the fact on the poll edit page
-  - [ ] There's no link to the results page (unless you are poll creator_)
+  - [x] There's no link to the results page (unless you are poll creator_)
   - [ ] You can't access the results page even by url (shows 404)
   - [ ] At the end of the poll it just "Thanks for filling this out!"
   - [ ] Check with "Create with AI" should be able to mark results as private

--- a/TODO.md
+++ b/TODO.md
@@ -1,6 +1,15 @@
 - [x] Find out why a polls/xxx page is not working
 - [x] Custom 404 Page
 - [ ] Privacy
+  - [x] Add a column for this in the database
+  - [ ] Add a toggle for this on the poll creation page
+  - [ ] Make sure the user can edit it after the fact on the poll edit page
+  - [ ] There's no link to the results page (unless you are poll creator_)
+  - [ ] You can't access the results page even by url (shows 404)
+  - [ ] At the end of the poll it just "Thanks for filling this out!"
+  - [ ] API endpoints
+  - [ ] Run on staging DB before pushing pull request
+  - [ ] Then Prod
 
 
 - [ ] I just signed up and it doesn't know that I have a pro plan. This should be fixed instantly, maybe through route revalidation on the success page or something.

--- a/TODO.md
+++ b/TODO.md
@@ -2,11 +2,13 @@
 - [x] Custom 404 Page
 - [ ] Privacy
   - [x] Add a column for this in the database
-  - [ ] Add a toggle for this on the poll creation page
-  - [ ] Make sure the user can edit it after the fact on the poll edit page
+  - [x] Add a toggle for this on the poll creation page
+  - [x] Make sure the user can edit it after the fact on the poll edit page
   - [ ] There's no link to the results page (unless you are poll creator_)
   - [ ] You can't access the results page even by url (shows 404)
   - [ ] At the end of the poll it just "Thanks for filling this out!"
+  - [ ] Check with "Create with AI" should be able to mark results as private
+  - [ ] Show on the polls list if the results are private
   - [ ] API endpoints
   - [ ] Run on staging DB before pushing pull request
   - [ ] Then Prod

--- a/TODO.md
+++ b/TODO.md
@@ -12,7 +12,7 @@
   - [x] Check with "Create with AI" should be able to mark results as private
   - [x] Show on the polls list if the results are private
   - [x] API endpoints
-  - [ ] Run on staging DB before pushing pull request
+  - [x] Run on staging DB before pushing pull request
   - [ ] Then Prod
 
 

--- a/TODO.md
+++ b/TODO.md
@@ -8,9 +8,9 @@
   - [x] You can't access the results page even by url (says results are private, 404 doesn't make sense to do)
   - [x] Also need to remove the "Copy link to results page" from share dropdown if results private
   - [x] Remove download CSV unless it's the poll creator
-  - [ ] At the end of the poll it just "Thanks for filling this out!"
-  - [ ] Check with "Create with AI" should be able to mark results as private
-  - [ ] Show on the polls list if the results are private
+  - [x] At the end of the poll it just "Thanks for filling this out!"
+  - [x] Check with "Create with AI" should be able to mark results as private
+  - [x] Show on the polls list if the results are private
   - [ ] API endpoints
   - [ ] Run on staging DB before pushing pull request
   - [ ] Then Prod

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "prepare": "husky",
     "e2e": "BASE_URL=http://localhost:3000  playwright test",
     "e2e:debug": "BASE_URL=http://localhost:3000  playwright test --ui",
-    "e2e:ci": "playwright test"
+    "e2e:ci": "playwright test",
+    "migrate": "bun run src/db/migrate.ts"
   },
   "dependencies": {
     "@ai-sdk/openai": "^1.0.7",

--- a/src/app/(app)/polls/[slug]/layout.tsx
+++ b/src/app/(app)/polls/[slug]/layout.tsx
@@ -37,6 +37,7 @@ export default async function PollLayout({
           slug={slug}
           isOwner={results.isOwner}
           pollId={results.poll.id}
+          resultsPublic={results.poll.results_public}
         />
         <h1 className="text-xl sm:text-3xl font-extrabold tracking-tight text-neutral-900 dark:text-neutral-100">
           {results.poll.title}

--- a/src/app/(app)/polls/[slug]/results/page.tsx
+++ b/src/app/(app)/polls/[slug]/results/page.tsx
@@ -1,4 +1,4 @@
-import { ResultsPage } from "@/components/ResultsPage";
+import ResultsPage from "@/components/ResultsPage";
 import { getPollResults } from "@/lib/getPollResults";
 import { getOptionalVisitorId } from "@/lib/getVisitorIdOrThrow";
 import { StatementReview } from "@/lib/schemas";

--- a/src/app/(app)/user/polls/[id]/page.tsx
+++ b/src/app/(app)/user/polls/[id]/page.tsx
@@ -1,7 +1,9 @@
 import { EditPollForm } from "@/components/EditPollForm";
 import { getPollAdminData } from "@/lib/getPollAdminData";
 import { auth, currentUser } from "@clerk/nextjs/server";
+import Link from "next/link";
 import { notFound } from "next/navigation";
+import { FiArchive, FiBarChart } from "react-icons/fi";
 
 export const dynamic = "force-dynamic";
 
@@ -21,6 +23,20 @@ export default async function PollAdminPage({ params }: PageProps) {
   return (
     <div className="max-w-4xl w-full mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-4">Poll Admin: {data.poll.title}</h1>
+      <div className="flex gap-2 mb-6">
+        <Link
+          href={`/polls/${data.poll.slug}`}
+          className="flex items-center gap-2 text-sm font-medium p-1 px-2 rounded-md transition-colors text-neutral-500 bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:text-neutral-400"
+        >
+          <FiArchive /> View Poll
+        </Link>
+        <Link
+          href={`/polls/${data.poll.slug}/results`}
+          className="flex items-center gap-2 text-sm font-medium p-1 px-2 rounded-md transition-colors text-neutral-500 bg-neutral-100 hover:bg-neutral-200 dark:bg-neutral-800 dark:hover:bg-neutral-700 dark:text-neutral-400"
+        >
+          <FiBarChart /> View Results
+        </Link>
+      </div>
       <EditPollForm {...data} />
     </div>
   );

--- a/src/app/(app)/user/polls/[id]/page.tsx
+++ b/src/app/(app)/user/polls/[id]/page.tsx
@@ -23,6 +23,10 @@ export default async function PollAdminPage({ params }: PageProps) {
   return (
     <div className="max-w-4xl w-full mx-auto px-4 py-8">
       <h1 className="text-2xl font-bold mb-4">Poll Admin: {data.poll.title}</h1>
+      <p className="mb-4 text-neutral-600 dark:text-neutral-400">
+        This is the edit page for your poll. Some fields can be changed, but
+        others are locked after creation.
+      </p>
       <div className="flex gap-2 mb-6">
         <Link
           href={`/polls/${data.poll.slug}`}

--- a/src/app/(app)/user/polls/page.tsx
+++ b/src/app/(app)/user/polls/page.tsx
@@ -2,7 +2,7 @@ import Link from "next/link";
 import { db } from "@/db/client";
 import { auth } from "@clerk/nextjs/server";
 import { notFound } from "next/navigation";
-import { FiArrowRight, FiEdit, FiPlus } from "react-icons/fi";
+import { FiArrowRight, FiBarChart, FiEdit, FiPlus } from "react-icons/fi";
 import { Button } from "@/ui/button";
 import { isUserPro } from "@/lib/isUserPro";
 import { UpgradeLink } from "@/components/UpgradeLink";
@@ -98,7 +98,7 @@ function UserPoll({
 }: Awaited<ReturnType<typeof getUserPolls>>[number]) {
   return (
     <div className="rounded-lg md:flex border shadow-sm bg-white dark:bg-neutral-800">
-      <Link href={`/polls/${slug}`} className="grid gap-2 p-4 md:p-6 flex-grow">
+      <Link href={`/polls/${slug}`} className="grid gap-1 p-4 md:p-5 flex-grow">
         <h2 className="text-lg leading-tight font-medium text-neutral-900 dark:text-neutral-50 text-pretty">
           {title}
         </h2>
@@ -114,6 +114,10 @@ function UserPoll({
         <Link href={`/polls/${slug}`} className={pollButton}>
           <FiArrowRight />
           View
+        </Link>
+        <Link href={`/polls/${slug}/results`} className={pollButton}>
+          <FiBarChart />
+          Results
         </Link>
       </div>
     </div>

--- a/src/components/EditPollForm.tsx
+++ b/src/components/EditPollForm.tsx
@@ -9,6 +9,7 @@ import { usePendingAction } from "@/lib/usePendingAction";
 import {
   deleteStatement,
   removeAllFlagsFromStatement,
+  setPollResultsPublic,
   toggleStatementVisibility,
 } from "@/lib/actions";
 import { toast } from "sonner";
@@ -39,6 +40,10 @@ export function EditPollForm({
         <EditNewStatementsVisibility
           pollId={poll.id}
           defaultValue={poll.new_statements_visible_by_default || false}
+        />
+        <EditResultsPublic
+          pollId={poll.id}
+          defaultValue={poll.results_public}
         />
         <FormField title="Statements">
           <div className="grid gap-2">
@@ -88,6 +93,45 @@ function EditNewStatementsVisibility({
         />
         <span className="ml-2 text-sm">
           {defaultValue ? "Initially visible" : "Initially hidden"}
+        </span>
+      </div>
+    </FormField>
+  );
+}
+
+function EditResultsPublic({
+  pollId,
+  defaultValue,
+}: {
+  pollId: number;
+  defaultValue: boolean;
+}) {
+  const [loading, handler] = usePendingAction(setPollResultsPublic, {
+    after: () => {
+      toast.success("Results page privacy updated");
+    },
+  });
+
+  const handleChange = (checked: boolean) => {
+    handler({ pollId, resultsPublic: checked });
+  };
+
+  return (
+    <FormField
+      title="Results Page Privacy"
+      description="If results are public, anyone with the link can view the results page. If private, only you (the poll creator) can see the results. You can change this later."
+      loading={loading}
+    >
+      <div className="flex items-center">
+        <Switch
+          checked={defaultValue}
+          onCheckedChange={handleChange}
+          disabled={loading}
+        />
+        <span className="ml-2 text-sm">
+          {defaultValue
+            ? "Public (anyone with the link can view)"
+            : "Private (only you can view)"}
         </span>
       </div>
     </FormField>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -3,7 +3,13 @@
 import Link, { LinkProps } from "next/link";
 import Image from "next/image";
 import { FiChevronDown, FiHome, FiMenu, FiPlus, FiX } from "react-icons/fi";
-import { SignedIn, SignedOut, SignInButton, UserButton } from "@clerk/nextjs";
+import {
+  SignedIn,
+  SignedOut,
+  SignInButton,
+  useAuth,
+  UserButton,
+} from "@clerk/nextjs";
 import { ModeToggle } from "./ModeToggle";
 import { useState } from "react";
 import { cn } from "@/ui/cn";
@@ -39,6 +45,7 @@ function MobileNavLinks({ onClose }: { onClose: () => void }) {
 
 export function Header() {
   const [isMenuOpen, setIsMenuOpen] = useState(false);
+  const { isSignedIn } = useAuth();
 
   const toggleMenu = () => setIsMenuOpen(!isMenuOpen);
   const closeMenu = () => setIsMenuOpen(false);
@@ -46,7 +53,10 @@ export function Header() {
   return (
     <header>
       <div className="flex items-center justify-between px-4 py-3">
-        <Link href="/" className="flex items-center">
+        <Link
+          href={isSignedIn ? "/user/polls" : "/"}
+          className="flex items-center"
+        >
           <Image
             src="/logo.png"
             className="dark:hidden"

--- a/src/components/NewPollForm.tsx
+++ b/src/components/NewPollForm.tsx
@@ -211,6 +211,30 @@ export function NewPollForm() {
                   </Label>
                 </div>
               </FormField>
+
+              <FormField
+                title="Results Page Privacy"
+                description="If results are public, anyone with the link can view the results page. If private, only you (the poll creator) can see the results. You can change this later."
+                errors={form.formState.errors.results_public}
+              >
+                <div className="flex items-center space-x-2">
+                  <Controller
+                    name="results_public"
+                    control={form.control}
+                    render={({ field }) => (
+                      <Switch
+                        checked={field.value}
+                        onCheckedChange={field.onChange}
+                      />
+                    )}
+                  />
+                  <Label htmlFor="results_public">
+                    {form.watch("results_public")
+                      ? "Public (anyone with the link can view)"
+                      : "Private (only you can view)"}
+                  </Label>
+                </div>
+              </FormField>
             </AccordionContent>
           </AccordionItem>
         </Accordion>

--- a/src/components/Poll.tsx
+++ b/src/components/Poll.tsx
@@ -29,6 +29,7 @@ export function Poll({
   poll,
   count,
   embedVisitorId,
+  isOwner,
 }: GetPollData & { embedVisitorId?: string }) {
   const [dragThreshold, setDragThreshold] = useState(200);
   useEffect(() => {
@@ -255,8 +256,10 @@ export function Poll({
               )}
             </PollStatement>
           </animated.div>
-        ) : (
+        ) : poll.results_public || isOwner ? (
           <GoToResults slug={poll.slug!} />
+        ) : (
+          <ThankYouForFillingOut />
         )}
       </AnimatePresence>
     </div>
@@ -428,4 +431,24 @@ export const GoToResults = forwardRef<HTMLDivElement, { slug: string }>(
 function useIsEmbed() {
   const path = usePathname();
   return path.startsWith("/embed");
+}
+
+function ThankYouForFillingOut() {
+  return (
+    <motion.div
+      className="grid gap-4 justify-items-center items-center justify-center content-center p-8 rounded-xl bg-neutral-100 dark:bg-neutral-800 min-h-[275px]"
+      initial={{ opacity: 0, scale: 0.9 }}
+      animate={{ opacity: 1, scale: 1 }}
+      exit={{ opacity: 0, scale: 1.2 }}
+      transition={{ duration: 0.4 }}
+    >
+      <h2 className="text-2xl font-extrabold text-center flex items-center gap-2">
+        🎉 Thank you for sharing your perspective!
+      </h2>
+      <p className="text-neutral-600 dark:text-neutral-300 text-center max-w-md">
+        Your responses have been submitted. This poll&apos;s results are
+        private, so only the creator can view them. We appreciate your input!
+      </p>
+    </motion.div>
+  );
 }

--- a/src/components/PollHeader.tsx
+++ b/src/components/PollHeader.tsx
@@ -145,10 +145,12 @@ export function PollHeader({
             <FiCode className="w-4 h-4 mr-2" />
             Copy embed code
           </DropdownMenuItem>
-          <DropdownMenuItem onSelect={() => handleDownload({ pollId })}>
-            <FiDownload className="w-4 h-4 mr-2" />
-            Download CSV
-          </DropdownMenuItem>
+          {(resultsPublic || isOwner) && (
+            <DropdownMenuItem onSelect={() => handleDownload({ pollId })}>
+              <FiDownload className="w-4 h-4 mr-2" />
+              Download CSV
+            </DropdownMenuItem>
+          )}
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/src/components/PollHeader.tsx
+++ b/src/components/PollHeader.tsx
@@ -110,21 +110,23 @@ export function PollHeader({
             <FiLink className="w-4 h-4 mr-2" />
             Copy link to poll
           </DropdownMenuItem>
-          <DropdownMenuItem
-            onSelect={() => {
-              posthog.capture("Share Poll Link", {
-                poll_slug: slug,
-                type: "results",
-              });
-              copyText(
-                `${getBaseUrl()}/polls/${slug}/results`,
-                "Results link copied to clipboard",
-              );
-            }}
-          >
-            <FiBarChart className="w-4 h-4 mr-2" />
-            Copy link to results
-          </DropdownMenuItem>
+          {resultsPublic && (
+            <DropdownMenuItem
+              onSelect={() => {
+                posthog.capture("Share Poll Link", {
+                  poll_slug: slug,
+                  type: "results",
+                });
+                copyText(
+                  `${getBaseUrl()}/polls/${slug}/results`,
+                  "Results link copied to clipboard",
+                );
+              }}
+            >
+              <FiBarChart className="w-4 h-4 mr-2" />
+              Copy link to results
+            </DropdownMenuItem>
+          )}
           <QRCodeDialog link={`${getBaseUrl()}/polls/${slug}`}>
             <DropdownMenuItem
               onSelect={(e) => {

--- a/src/components/PollHeader.tsx
+++ b/src/components/PollHeader.tsx
@@ -34,10 +34,12 @@ export function PollHeader({
   slug,
   isOwner,
   pollId,
+  resultsPublic,
 }: {
   slug: string;
   isOwner: boolean;
   pollId: number;
+  resultsPublic: boolean;
 }) {
   const pathname = usePathname();
   const isResultsPage = pathname.endsWith("/results");
@@ -69,15 +71,16 @@ export function PollHeader({
 
   return (
     <div className="flex gap-1 items-center mb-3 justify-end">
-      {isResultsPage ? (
-        <PollButton icon={FiArchive} href={`/polls/${slug}`}>
-          Vote
-        </PollButton>
-      ) : (
-        <PollButton icon={FiBarChart} href={`/polls/${slug}/results`}>
-          Results
-        </PollButton>
-      )}
+      {(resultsPublic || isOwner) &&
+        (isResultsPage ? (
+          <PollButton icon={FiArchive} href={`/polls/${slug}`}>
+            Vote
+          </PollButton>
+        ) : (
+          <PollButton icon={FiBarChart} href={`/polls/${slug}/results`}>
+            Results
+          </PollButton>
+        ))}
       {isOwner ? (
         <PollButton icon={FiEdit} href={`/user/polls/${pollId}`}>
           Edit

--- a/src/db/RUN_BEFORE_MIGRATIONS.sql
+++ b/src/db/RUN_BEFORE_MIGRATIONS.sql
@@ -1,0 +1,462 @@
+--
+-- PostgreSQL database dump
+--
+
+-- Dumped from database version 14.9 (Homebrew)
+-- Dumped by pg_dump version 14.9 (Homebrew)
+
+--
+-- Name: choice_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.choice_enum AS ENUM (
+    'agree',
+    'disagree',
+    'skip',
+    'itsComplicated'
+);
+
+
+--
+-- Name: polls_visibility_enum; Type: TYPE; Schema: public; Owner: -
+--
+
+CREATE TYPE public.polls_visibility_enum AS ENUM (
+    'public',
+    'hidden',
+    'private'
+);
+
+
+SET default_tablespace = '';
+
+SET default_table_access_method = heap;
+
+--
+-- Name: Author; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Author" (
+    id integer NOT NULL,
+    "userId" text NOT NULL,
+    name text,
+    "avatarUrl" text,
+    "createdAt" timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: Author_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public."Author_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: Author_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public."Author_id_seq" OWNED BY public."Author".id;
+
+
+--
+-- Name: Comment; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Comment" (
+    id integer NOT NULL,
+    "userId" text,
+    "sessionId" character varying NOT NULL,
+    text text NOT NULL,
+    "createdAt" timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    "pollId" integer NOT NULL
+);
+
+
+--
+-- Name: Comment_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public."Comment_id_seq"
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: Comment_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public."Comment_id_seq" OWNED BY public."Comment".id;
+
+
+--
+-- Name: FlaggedStatement; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."FlaggedStatement" (
+    id integer NOT NULL,
+    "statementId" integer NOT NULL,
+    user_id text,
+    session_id character varying NOT NULL,
+    reason text,
+    created_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    description text
+);
+
+
+--
+-- Name: Statement; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public."Statement" (
+    id integer NOT NULL,
+    poll_id integer NOT NULL,
+    user_id text,
+    session_id character varying,
+    text text NOT NULL,
+    created_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: _prisma_migrations; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public._prisma_migrations (
+    id character varying(36) NOT NULL,
+    checksum character varying(64) NOT NULL,
+    finished_at timestamp with time zone,
+    migration_name character varying(255) NOT NULL,
+    logs text,
+    rolled_back_at timestamp with time zone,
+    started_at timestamp with time zone DEFAULT now() NOT NULL,
+    applied_steps_count integer DEFAULT 0 NOT NULL
+);
+
+
+--
+-- Name: comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.comments_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.comments_id_seq OWNED BY public."Statement".id;
+
+
+--
+-- Name: flagged_comments_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.flagged_comments_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: flagged_comments_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.flagged_comments_id_seq OWNED BY public."FlaggedStatement".id;
+
+
+--
+-- Name: polls; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.polls (
+    id integer NOT NULL,
+    user_id text NOT NULL,
+    slug character varying,
+    title character varying NOT NULL,
+    core_question text NOT NULL,
+    created_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+    visibility public.polls_visibility_enum DEFAULT 'public'::public.polls_visibility_enum NOT NULL,
+    analytics_filters jsonb DEFAULT '{}'::jsonb NOT NULL
+);
+
+
+--
+-- Name: polls_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.polls_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: polls_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.polls_id_seq OWNED BY public.polls.id;
+
+
+--
+-- Name: responses; Type: TABLE; Schema: public; Owner: -
+--
+
+CREATE TABLE public.responses (
+    id integer NOT NULL,
+    user_id text,
+    "statementId" integer NOT NULL,
+    session_id character varying NOT NULL,
+    choice public.choice_enum NOT NULL,
+    created_at timestamp(6) with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
+);
+
+
+--
+-- Name: responses_id_seq; Type: SEQUENCE; Schema: public; Owner: -
+--
+
+CREATE SEQUENCE public.responses_id_seq
+    AS integer
+    START WITH 1
+    INCREMENT BY 1
+    NO MINVALUE
+    NO MAXVALUE
+    CACHE 1;
+
+
+--
+-- Name: responses_id_seq; Type: SEQUENCE OWNED BY; Schema: public; Owner: -
+--
+
+ALTER SEQUENCE public.responses_id_seq OWNED BY public.responses.id;
+
+
+--
+-- Name: Author id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Author" ALTER COLUMN id SET DEFAULT nextval('public."Author_id_seq"'::regclass);
+
+
+--
+-- Name: Comment id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Comment" ALTER COLUMN id SET DEFAULT nextval('public."Comment_id_seq"'::regclass);
+
+
+--
+-- Name: FlaggedStatement id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."FlaggedStatement" ALTER COLUMN id SET DEFAULT nextval('public.flagged_comments_id_seq'::regclass);
+
+
+--
+-- Name: Statement id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Statement" ALTER COLUMN id SET DEFAULT nextval('public.comments_id_seq'::regclass);
+
+
+--
+-- Name: polls id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.polls ALTER COLUMN id SET DEFAULT nextval('public.polls_id_seq'::regclass);
+
+
+--
+-- Name: responses id; Type: DEFAULT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.responses ALTER COLUMN id SET DEFAULT nextval('public.responses_id_seq'::regclass);
+
+
+--
+-- Name: Author Author_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Author"
+    ADD CONSTRAINT "Author_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: Comment Comment_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Comment"
+    ADD CONSTRAINT "Comment_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: FlaggedStatement FlaggedStatement_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."FlaggedStatement"
+    ADD CONSTRAINT "FlaggedStatement_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: Statement Statement_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Statement"
+    ADD CONSTRAINT "Statement_pkey" PRIMARY KEY (id);
+
+
+--
+-- Name: _prisma_migrations _prisma_migrations_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public._prisma_migrations
+    ADD CONSTRAINT _prisma_migrations_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: polls polls_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.polls
+    ADD CONSTRAINT polls_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: responses responses_pkey; Type: CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.responses
+    ADD CONSTRAINT responses_pkey PRIMARY KEY (id);
+
+
+--
+-- Name: Author_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX "Author_id_key" ON public."Author" USING btree (id);
+
+
+--
+-- Name: Author_userId_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX "Author_userId_key" ON public."Author" USING btree ("userId");
+
+
+--
+-- Name: Comment_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX "Comment_id_key" ON public."Comment" USING btree (id);
+
+
+--
+-- Name: FlaggedStatement_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX "FlaggedStatement_id_key" ON public."FlaggedStatement" USING btree (id);
+
+
+--
+-- Name: Statement_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX "Statement_id_key" ON public."Statement" USING btree (id);
+
+
+--
+-- Name: polls_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX polls_id_key ON public.polls USING btree (id);
+
+
+--
+-- Name: polls_slug_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX polls_slug_key ON public.polls USING btree (slug);
+
+
+--
+-- Name: responses_id_key; Type: INDEX; Schema: public; Owner: -
+--
+
+CREATE UNIQUE INDEX responses_id_key ON public.responses USING btree (id);
+
+
+--
+-- Name: Comment Comment_pollId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Comment"
+    ADD CONSTRAINT "Comment_pollId_fkey" FOREIGN KEY ("pollId") REFERENCES public.polls(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Comment Comment_userId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Comment"
+    ADD CONSTRAINT "Comment_userId_fkey" FOREIGN KEY ("userId") REFERENCES public."Author"("userId");
+
+
+--
+-- Name: FlaggedStatement FlaggedStatement_statementId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."FlaggedStatement"
+    ADD CONSTRAINT "FlaggedStatement_statementId_fkey" FOREIGN KEY ("statementId") REFERENCES public."Statement"(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Statement Statement_poll_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Statement"
+    ADD CONSTRAINT "Statement_poll_id_fkey" FOREIGN KEY (poll_id) REFERENCES public.polls(id) ON DELETE CASCADE;
+
+
+--
+-- Name: Statement Statement_user_id_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public."Statement"
+    ADD CONSTRAINT "Statement_user_id_fkey" FOREIGN KEY (user_id) REFERENCES public."Author"("userId");
+
+
+--
+-- Name: responses responses_statementId_fkey; Type: FK CONSTRAINT; Schema: public; Owner: -
+--
+
+ALTER TABLE ONLY public.responses
+    ADD CONSTRAINT "responses_statementId_fkey" FOREIGN KEY ("statementId") REFERENCES public."Statement"(id) ON DELETE CASCADE;
+
+
+--
+-- PostgreSQL database dump complete
+--
+

--- a/src/db/migrate.ts
+++ b/src/db/migrate.ts
@@ -1,0 +1,165 @@
+/* eslint-disable no-console */
+
+import * as path from "path";
+import { Pool } from "pg";
+import { promises as fs } from "fs";
+import {
+  FileMigrationProvider,
+  Kysely,
+  Migrator,
+  PostgresDialect,
+} from "kysely";
+import type { Database } from "./schema";
+
+// Setup
+// -----------------------------------------------------------------------------
+
+const db = new Kysely<Database>({
+  dialect: new PostgresDialect({
+    pool: new Pool({
+      connectionString: process.env.DATABASE_URL,
+    }),
+  }),
+});
+
+const migrator = new Migrator({
+  db,
+  provider: new FileMigrationProvider({
+    fs,
+    path,
+    migrationFolder: path.join(__dirname, "migrations"),
+  }),
+});
+
+const newMigrationTemplate = `import type { Kysely } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // up
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  // down
+}
+`;
+
+// Up
+// -----------------------------------------------------------------------------
+
+async function migrateUp() {
+  const { error, results } = await migrator.migrateToLatest();
+
+  results?.forEach((it) => {
+    if (it.status === "Success") {
+      console.log(`migration "${it.migrationName}" was executed successfully`);
+    } else if (it.status === "Error") {
+      console.error(`failed to execute migration "${it.migrationName}"`);
+    }
+  });
+
+  if (error) {
+    console.error("failed to migrate up");
+    console.error(error);
+    process.exit(1);
+  }
+
+  await db.destroy();
+}
+
+// Down
+// -----------------------------------------------------------------------------
+
+async function migrateDown() {
+  const { error, results } = await migrator.migrateDown();
+
+  results?.forEach((it) => {
+    if (it.status === "Success") {
+      console.log(`migration "${it.migrationName}" was reverted successfully`);
+    } else if (it.status === "Error") {
+      console.error(`failed to revert migration "${it.migrationName}"`);
+    }
+  });
+
+  if (error) {
+    console.error("failed to migrate down");
+    console.error(error);
+    process.exit(1);
+  }
+
+  await db.destroy();
+}
+
+// Version
+// -----------------------------------------------------------------------------
+
+async function migrateVersion() {
+  const migrations = await migrator.getMigrations();
+
+  const lastMigrationToBeExecuted = migrations
+    .filter((it) => !!it.executedAt)
+    .slice(-1)[0];
+
+  const migrationsToExecute = migrations.filter((it) => !it.executedAt);
+
+  if (lastMigrationToBeExecuted) {
+    console.log(
+      `last migration to be executed: ${lastMigrationToBeExecuted?.name}`,
+    );
+  }
+
+  if (migrationsToExecute.length === 0) {
+    console.log("no more migrations to execute");
+  } else {
+    console.log("migrations to execute:");
+    migrationsToExecute.forEach((it) => console.log(`- ${it.name}`));
+  }
+
+  await db.destroy();
+}
+
+// Make
+// -----------------------------------------------------------------------------
+
+async function migrateMake() {
+  const name = process.argv[3];
+  if (!name) {
+    console.error("missing migration name");
+    process.exit(1);
+  }
+
+  const filename = `${Date.now()}_${name}.ts`;
+  const filepath = path.join(__dirname, "migrations", filename);
+
+  await fs.writeFile(filepath, newMigrationTemplate);
+
+  console.log(`created migration "${filename}"`);
+  await db.destroy();
+}
+
+// Handle command
+// -----------------------------------------------------------------------------
+
+const [cmd] = process.argv.slice(2);
+
+switch (cmd) {
+  case "up":
+    await migrateUp();
+    break;
+
+  case "down":
+    await migrateDown();
+    break;
+
+  case "version":
+    await migrateVersion();
+    break;
+
+  case "make":
+    await migrateMake();
+    break;
+
+  default:
+    console.error(`Usage: bun run migrate <command>`);
+    console.error(`Available commands: up, down, version, make`);
+    break;
+}

--- a/src/db/migrations/1698689790915_remove_prisma_migrations.ts
+++ b/src/db/migrations/1698689790915_remove_prisma_migrations.ts
@@ -1,0 +1,33 @@
+import { type Kysely, sql } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema.dropTable("_prisma_migrations").execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await sql`
+    CREATE TABLE "public"."_prisma_migrations" (
+      "id" varchar NOT NULL,
+      "checksum" varchar NOT NULL,
+      "finished_at" timestamptz,
+      "migration_name" varchar NOT NULL,
+      "logs" text,
+      "rolled_back_at" timestamptz,
+      "started_at" timestamptz NOT NULL DEFAULT now(),
+      "applied_steps_count" int4 NOT NULL DEFAULT 0,
+      PRIMARY KEY ("id")
+    );
+  `.execute(db);
+
+  await sql`
+    INSERT INTO "public"."_prisma_migrations" ("id", "checksum", "finished_at", "migration_name", "logs", "rolled_back_at", "started_at", "applied_steps_count") VALUES
+    ('0bf2d42f-067a-47e6-91c3-714366964810', '485372434313bece52c35189c620df4d59a280f3e2156e48e3c37dfbc1163839', '2023-10-19 20:00:52.006303+02', '20230814201226_fix_rename_comments_to_statement', NULL, NULL, '2023-10-19 20:00:52.005655+02', 1),
+    ('58fca389-3cc9-49fe-aef0-ff641dec0f1b', 'a1220d7174689f102ce7d57bbfecb5870432b4a3d53ecbb2d40a29a32f94d7fb', '2023-10-19 20:00:51.999454+02', '0_init', NULL, NULL, '2023-10-19 20:00:51.983839+02', 1),
+    ('a6f06fc5-41e5-46cc-af8d-da2db4e6ca7d', '9b2b88d149edd8b1bca9bc7ed8c7af5fa519eb061375df0c76b36a4fcdd3d43d', '2023-10-19 20:00:52.013373+02', '20230821141430_remove_statement_editing', NULL, NULL, '2023-10-19 20:00:52.012603+02', 1),
+    ('aa5daa22-e72f-45d5-969d-c8645793fab9', 'b4a2a00686e61955b85794e8ba4a8a9d35d2e23b67a52bcc7b630b0beeb938ee', '2023-10-19 20:00:52.003544+02', '20230803111931_rename_valence_to_choice', NULL, NULL, '2023-10-19 20:00:51.999967+02', 1),
+    ('b6d334cc-e99a-4487-bbfe-c922f985177a', '4eabb127ab2d2d8100983f202d13ebacd3f58e358d08033afd644b590e2e2ef5', '2023-10-19 20:00:52.011343+02', '20230815115418_add_author_table', NULL, NULL, '2023-10-19 20:00:52.006567+02', 1),
+    ('e23121b1-edb9-4b77-a047-799ee235bae5', '2de84a15ece4190e37590f6fb84e74519592902cc49583fcea34f27db06a61a1', '2023-10-19 20:00:52.012329+02', '20230820145837_add_description_to_flagged_statements', NULL, NULL, '2023-10-19 20:00:52.011597+02', 1),
+    ('ea1af5e1-a149-4167-be77-42142b5244d0', 'dd83b9ab6ac528a6d5d63740ddce952c4ed0f08fd8b8b9281143359773c01624', '2023-10-19 20:00:52.005234+02', '20230814201225_rename_comments_to_statement', NULL, NULL, '2023-10-19 20:00:52.003969+02', 1);
+  `.execute(db);
+}

--- a/src/db/migrations/1698851560735_create_sessions_table.ts
+++ b/src/db/migrations/1698851560735_create_sessions_table.ts
@@ -1,0 +1,16 @@
+import type { Kysely } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .createTable("sessions")
+    .addColumn("id", "text", (col) => col.notNull().primaryKey())
+    .addColumn("user_id", "text")
+    .addColumn("ip_address", "text")
+    .addColumn("user_agent", "text")
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.dropTable("sessions").execute();
+}

--- a/src/db/migrations/1698854535599_create_statement_options_table.ts
+++ b/src/db/migrations/1698854535599_create_statement_options_table.ts
@@ -1,0 +1,85 @@
+import { type Kysely, sql } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // let's rename the tables to make them more consistent
+
+  await db.schema.alterTable("Statement").renameTo("statements").execute();
+  await db.schema
+    .alterTable("FlaggedStatement")
+    .renameTo("flagged_statements")
+    .execute();
+  await db.schema.alterTable("Author").renameTo("authors").execute();
+  await db.schema.alterTable("Comment").renameTo("comments").execute();
+
+  // there is now a statement_options table, which contains the options for a statement
+
+  await db.schema
+    .createTable("statement_options")
+    .addColumn("id", "serial", (col) => col.primaryKey())
+    .addColumn("statement_id", "integer", (col) =>
+      col.notNull().references("statements.id"),
+    )
+    .addColumn("option", "text", (col) => col.notNull())
+    .addColumn("icon", "text")
+    .execute();
+
+  // statements can now have a custom question_type and answer_type
+
+  await db.schema
+    .createType("statements_question_type")
+    .asEnum(["default", "demographic"])
+    .execute();
+
+  await db.schema
+    .createType("statements_answer_type")
+    .asEnum(["default", "custom_options"])
+    .execute();
+
+  await db.schema
+    .alterTable("statements")
+    .addColumn("question_type", sql`statements_question_type`, (col) =>
+      col.defaultTo("default"),
+    )
+    .addColumn("answer_type", sql`statements_answer_type`, (col) =>
+      col.defaultTo("default"),
+    )
+    .execute();
+
+  // responses now keeps track of statement options, if the answer_type is custom_options
+
+  await db.schema
+    .alterTable("responses")
+    .alterColumn("choice", (col) => col.dropNotNull())
+    .execute();
+
+  await db.schema
+    .alterTable("responses")
+    .addColumn("option_id", "integer", (col) =>
+      col.references("statement_options.id"),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("responses").dropColumn("option_id").execute();
+  await db.schema
+    .alterTable("responses")
+    .alterColumn("choice", (col) => col.setNotNull())
+    .execute();
+  await db.schema.alterTable("statements").dropColumn("answer_type").execute();
+  await db.schema
+    .alterTable("statements")
+    .dropColumn("question_type")
+    .execute();
+  await db.schema.dropType("statements_answer_type").execute();
+  await db.schema.dropType("statements_question_type").execute();
+  await db.schema.dropTable("statement_options").execute();
+  await db.schema.alterTable("authors").renameTo("Author").execute();
+  await db.schema
+    .alterTable("flagged_statements")
+    .renameTo("FlaggedStatement")
+    .execute();
+  await db.schema.alterTable("statements").renameTo("Statement").execute();
+  await db.schema.alterTable("comments").renameTo("Comment").execute();
+}

--- a/src/db/migrations/1709923597195_remove_complicated_choice.ts
+++ b/src/db/migrations/1709923597195_remove_complicated_choice.ts
@@ -1,0 +1,68 @@
+// @ts-nocheck
+
+import { type Kysely, sql } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // Update existing responses with 'itsComplicated' to 'skip'
+  await db
+    .updateTable("responses")
+    .set({ choice: "skip" })
+    .where("choice", "=", "itsComplicated")
+    .execute();
+
+  // Remove 'itsComplicated' from the choice_enum
+  await sql`
+    ALTER TYPE public.choice_enum 
+    RENAME TO choice_enum_old;
+  `.execute(db);
+
+  await sql`
+    CREATE TYPE public.choice_enum AS ENUM (
+      'agree',
+      'disagree',
+      'skip'
+    );
+  `.execute(db);
+
+  await sql`
+    ALTER TABLE public.responses 
+    ALTER COLUMN choice TYPE public.choice_enum 
+    USING choice::text::public.choice_enum;
+  `.execute(db);
+
+  await sql`
+    DROP TYPE public.choice_enum_old;
+  `.execute(db);
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  // Recreate the old enum with 'itsComplicated'
+  await sql`
+    ALTER TYPE public.choice_enum 
+    RENAME TO choice_enum_new;
+  `.execute(db);
+
+  await sql`
+    CREATE TYPE public.choice_enum AS ENUM (
+      'agree',
+      'disagree',
+      'skip',
+      'itsComplicated'
+    );
+  `.execute(db);
+
+  // Update the column to use the old enum
+  await sql`
+    ALTER TABLE public.responses 
+    ALTER COLUMN choice TYPE public.choice_enum 
+    USING choice::text::public.choice_enum;
+  `.execute(db);
+
+  // Drop the new enum without 'itsComplicated'
+  await sql`
+    DROP TYPE public.choice_enum_new;
+  `.execute(db);
+
+  // No need to update the 'skip' back to 'itsComplicated' as this would be data loss
+}

--- a/src/db/migrations/1711405685659_statement_review_flow.ts
+++ b/src/db/migrations/1711405685659_statement_review_flow.ts
@@ -1,0 +1,29 @@
+import type { Kysely } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  // Add 'visible' column to 'statements' table
+  await db.schema
+    .alterTable("statements")
+    .addColumn("visible", "boolean", (col) => col.defaultTo(true))
+    .execute();
+
+  // Add 'new_statements_visible_by_default' column to 'polls' table
+  await db.schema
+    .alterTable("polls")
+    .addColumn("new_statements_visible_by_default", "boolean", (col) =>
+      col.defaultTo(false),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  // Remove 'visible' column from 'statements' table
+  await db.schema.alterTable("statements").dropColumn("visible").execute();
+
+  // Remove 'new_statements_visible_by_default' column from 'polls' table
+  await db.schema
+    .alterTable("polls")
+    .dropColumn("new_statements_visible_by_default")
+    .execute();
+}

--- a/src/db/migrations/1749041502307_add_results_private_to_polls.ts
+++ b/src/db/migrations/1749041502307_add_results_private_to_polls.ts
@@ -1,0 +1,15 @@
+import type { Kysely } from "kysely";
+import type { Database } from "../schema";
+
+export async function up(db: Kysely<Database>): Promise<void> {
+  await db.schema
+    .alterTable("polls")
+    .addColumn("results_public", "boolean", (col) =>
+      col.notNull().defaultTo(true),
+    )
+    .execute();
+}
+
+export async function down(db: Kysely<Database>): Promise<void> {
+  await db.schema.alterTable("polls").dropColumn("results_public").execute();
+}

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,0 +1,17 @@
+import type { Insertable, Selectable } from "kysely";
+import type { DB } from "kysely-codegen";
+
+/**
+ * Types are generated during postinall by the kysely-codegen plugin.
+ *
+ * These types are helpful for type checking and autocompletion when working with the database.
+ */
+
+export type Database = DB;
+export type Poll = Selectable<DB["polls"]>;
+export type Statement = Selectable<DB["statements"]>;
+export type NewStatement = Insertable<DB["statements"]>;
+export type StatementOption = Selectable<DB["statement_options"]>;
+export type FlaggedStatement = Selectable<DB["flagged_statements"]>;
+export type Response = Selectable<DB["responses"]>;
+export type Author = Selectable<DB["authors"]>;

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -9,6 +9,7 @@ import type { DB } from "kysely-codegen";
 
 export type Database = DB;
 export type Poll = Selectable<DB["polls"]>;
+export type NewPoll = Insertable<DB["polls"]>;
 export type Statement = Selectable<DB["statements"]>;
 export type NewStatement = Insertable<DB["statements"]>;
 export type StatementOption = Selectable<DB["statement_options"]>;

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -449,3 +449,21 @@ export async function generatePollWithAI({
     };
   }
 }
+
+/**
+ * Sets the results_public field for a poll
+ */
+export async function setPollResultsPublic({
+  pollId,
+  resultsPublic,
+}: {
+  pollId: number;
+  resultsPublic: boolean;
+}) {
+  await db
+    .updateTable("polls")
+    .set({ results_public: resultsPublic })
+    .where("id", "=", pollId)
+    .execute();
+  revalidatePath(`/user/polls/${pollId}`);
+}

--- a/src/lib/actions.ts
+++ b/src/lib/actions.ts
@@ -60,6 +60,7 @@ export async function createPoll({
   slug,
   question,
   with_demographic_questions,
+  results_public = true,
   statements: statementsInput,
 }: CreatePoll) {
   const user = await currentUser();
@@ -87,6 +88,7 @@ export async function createPoll({
         visibility: "private",
         new_statements_visible_by_default,
         analytics_filters: {},
+        results_public,
       })
       .returningAll()
       .executeTakeFirstOrThrow();

--- a/src/lib/schemas.ts
+++ b/src/lib/schemas.ts
@@ -26,6 +26,7 @@ export const createPollSchema = z.object({
   ),
   with_demographic_questions: z.boolean().default(false),
   new_statements_visible_by_default: z.boolean().default(true),
+  results_public: z.boolean().default(true),
 });
 
 export type CreatePoll = z.infer<typeof createPollSchema>;

--- a/src/lib/useCreatePollStore.ts
+++ b/src/lib/useCreatePollStore.ts
@@ -12,6 +12,7 @@ const initialStore: UseCreatePollStore = {
   statements: "",
   with_demographic_questions: false,
   new_statements_visible_by_default: true,
+  results_public: true,
   question: DEFAULT_CORE_QUESTION,
 };
 export const useCreatePollStore = create<UseCreatePollStore>()(

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "strict": true,
     "noEmit": true,
     "esModuleInterop": true,
+    "target": "es2023",
     "module": "esnext",
     "moduleResolution": "bundler",
     "resolveJsonModule": true,


### PR DESCRIPTION
- **Link header to polls when logged in**
- **Add direct results link**
- **Update database**
- **feat: add results_public toggle to poll creation (privacy control)**
- **feat: allow editing results_public (privacy) on poll edit page**
- **feat: hide results link unless results are public or user is poll creator**
- **refactor: use Next.js Link for poll and results links on edit page for consistency and SPA navigation**
- **refactor: ResultsPage uses discriminated union for private/public results, fixes all type errors**
- **Hide 'Copy link to results' in share dropdown if results are private (not public)**
- **Show 'Download CSV' in share dropdown only if results are public or user is poll owner**
- **Show thank you message at end of poll if results are private and user is not owner**
- **Tweak lock icon size and alignment for private results badge on user polls page**
- **Add migrate script**
